### PR TITLE
Fix NUnit parallelization attribute

### DIFF
--- a/src/xRetry.SpecFlow/CustomNUnit3TestGeneratorProvider.cs
+++ b/src/xRetry.SpecFlow/CustomNUnit3TestGeneratorProvider.cs
@@ -42,7 +42,13 @@ namespace xRetry.SpecFlow
 
         public override void SetTestClassParallelize(TestClassGenerationContext generationContext)
         {
-            CodeDomHelper.AddAttribute(generationContext.TestClass, PARALLELIZABLE_ATTR, new CodeAttributeArgument(new CodePrimitiveExpression(generationContext.TestClass.Name)));
+            CodeDomHelper.AddAttribute(
+                generationContext.TestClass,
+                PARALLELIZABLE_ATTR,
+                new CodeAttributeArgument(
+                    new CodeFieldReferenceExpression(
+                        new CodeTypeReferenceExpression("NUnit.Framework.ParallelScope"),
+                        "Fixtures")));
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix argument passed to NUnit `[Parallelizable]` attribute

## Testing
- `make unit-tests-run` *(fails: cd ../test/UnitTests: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687f67aa3b4c832990e672d25ba40779